### PR TITLE
Support custom elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Support for defining additional HTML elements
+
 ## 0.2.0
 
 - Wrap `radio_buttton/4` from Phoenix.HTML.Form

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ temple do
 end
 ```
 
+### Custom elements
+
+Temple can be extended with custom HTML elements.
+
+In config.exs:
+
+```elixir
+config :temple,
+  nonvoid_elements: ~w[
+    svg path
+  ]a,
+  void_elements: ~w[
+    somethingcustom
+  ]a
+```
+
 ### Phoenix.HTML
 
 Temple provides macros for working with the helpers provided by the [Phoenix.HTML](https://www.github.com/phoenixframework/phoenix_html) package.

--- a/lib/temple/tags.ex
+++ b/lib/temple/tags.ex
@@ -58,7 +58,7 @@ defmodule Temple.Tags do
   ```
   """
 
-  @nonvoid_elements ~w[
+  @default_nonvoid_elements ~w[
     html
     head title style script
     noscript template
@@ -76,10 +76,16 @@ defmodule Temple.Tags do
     details summary menuitem menu
   ]a
 
-  @void_elements ~w[
+  @default_void_elements ~w[
     meta link base
     area br col embed hr img input keygen param source track wbr
   ]a
+
+  @additional_nonvoid_elements Application.get_env(:temple, :nonvoid_elements, [])
+  @additional_void_elements Application.get_env(:temple, :void_elements, [])
+
+  @nonvoid_elements @default_nonvoid_elements ++ @additional_nonvoid_elements
+  @void_elements @default_void_elements ++ @additional_void_elements
 
   @doc false
   def nonvoid_elements, do: @nonvoid_elements


### PR DESCRIPTION
It would be nice to extend Temple with additional elements.

For example:
```elixir
defcomponent :icon_heart do
    svg viewBox: "0 0 100 100", xmlns: "http://www.w3.org/2000/svg" do
      path d: "M 10,30
               A 20,20 0,0,1 50,30
               A 20,20 0,0,1 90,30
               Q 90,60 50,90
               Q 10,60 10,30 z"
    end
end
```
is preferable to:
```elixir
defcomponent :icon_heart do
    partial Phoenix.HTML.raw("""
            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
              <path d="M 10,30
                      A 20,20 0,0,1 50,30
                      A 20,20 0,0,1 90,30
                      Q 90,60 50,90
                      Q 10,60 10,30 z"/>
            </svg>
            """)
  end
```
especially when passing attributes from components to custom elements.

Application configuration doesn't seem like the best way to do this.  I don't even know how to write a test for this because of how it's configured.  I just don't know if you're open to a substantial change of the `Temple.Tags` module to do this differently.

Thoughts?