### PR TITLE
Updated html macro to put a <!DOCTYPE html> before the <html /> tag (Issue #17)

### DIFF
--- a/lib/temple/tags.ex
+++ b/lib/temple/tags.ex
@@ -59,7 +59,6 @@ defmodule Temple.Tags do
   """
 
   @nonvoid_elements ~w[
-    html
     head title style script
     noscript template
     body section nav article aside h1 h2 h3 h4 h5 h6
@@ -154,6 +153,60 @@ defmodule Temple.Tags do
           "<#{unquote(el)}#{Temple.Utils.compile_attrs(attrs)}>"
         )
       end
+    end
+  end
+
+  @doc if File.exists?("./tmp/docs/html.txt"), do: File.read!("./tmp/docs/html.txt")
+  defmacro unquote(:html)() do
+    quote do
+      Temple.Utils.put_buffer(var!(buff, Temple.Tags), "<!DOCTYPE html>")
+      Temple.Utils.put_open_tag(var!(buff, Temple.Tags), unquote(:html), [])
+      Temple.Utils.put_close_tag(var!(buff, Temple.Tags), unquote(:html))
+    end
+  end
+
+  defmacro unquote(:html)(attrs_or_content_or_block)
+
+  defmacro unquote(:html)([{:do, inner}]) do
+    quote do
+      Temple.Utils.put_buffer(var!(buff, Temple.Tags), "<!DOCTYPE html>")
+      Temple.Utils.put_open_tag(var!(buff, Temple.Tags), unquote(:html), [])
+      _ = unquote(inner)
+      Temple.Utils.put_close_tag(var!(buff, Temple.Tags), unquote(:html))
+    end
+  end
+
+  defmacro unquote(:html)(attrs_or_content) do
+    quote do
+      Temple.Utils.put_buffer(var!(buff, Temple.Tags), "<!DOCTYPE html>")
+
+      Temple.Utils.put_open_tag(
+        var!(buff, Temple.Tags),
+        unquote(:html),
+        unquote(attrs_or_content)
+      )
+
+      Temple.Utils.put_close_tag(var!(buff, Temple.Tags), unquote(:html))
+    end
+  end
+
+  defmacro unquote(:html)(attrs_or_content, block_or_attrs)
+
+  defmacro unquote(:html)(attrs, [{:do, inner}] = _block) do
+    quote do
+      Temple.Utils.put_buffer(var!(buff, Temple.Tags), "<!DOCTYPE html>")
+      Temple.Utils.put_open_tag(var!(buff, Temple.Tags), unquote_splicing([:html, attrs]))
+      _ = unquote(inner)
+      Temple.Utils.put_close_tag(var!(buff, Temple.Tags), unquote(:html))
+    end
+  end
+
+  defmacro unquote(:html)(content, attrs) do
+    quote do
+      Temple.Utils.put_buffer(var!(buff, Temple.Tags), "<!DOCTYPE html>")
+      Temple.Utils.put_open_tag(var!(buff, Temple.Tags), unquote_splicing([:html, attrs]))
+      text unquote(content)
+      Temple.Utils.put_close_tag(var!(buff, Temple.Tags), unquote(:html))
     end
   end
 end

--- a/test/temple/tags_test.exs
+++ b/test/temple/tags_test.exs
@@ -2,6 +2,73 @@ defmodule Temple.TagsTest do
   use ExUnit.Case, async: true
   use Temple
 
+  # Seperate tests for the html tag
+
+  test "renders a html" do
+    {:safe, result} =
+      temple do
+        html()
+      end
+
+    assert result == ~s{<!DOCTYPE html><html></html>}
+  end
+
+  test "renders a html with attrs" do
+    {:safe, result} =
+      temple do
+        html(class: "hello")
+      end
+
+    assert result == ~s{<!DOCTYPE html><html class="hello"></html>}
+  end
+
+  test "renders a html with content" do
+    {:safe, result} =
+      temple do
+        html "Hi"
+      end
+
+    assert result == "<!DOCTYPE html><html>Hi</html>"
+  end
+
+  test "renders a html with escaped content" do
+    {:safe, result} =
+      temple do
+        html("<div>1</div>")
+      end
+
+    assert result == "<!DOCTYPE html><html>&lt;div&gt;1&lt;/div&gt;</html>"
+  end
+
+  test "renders a html with attrs and content" do
+    {:safe, result} =
+      temple do
+        html("Hi", class: "hello")
+      end
+
+    assert result == ~s{<!DOCTYPE html><html class="hello">Hi</html>}
+  end
+
+  test "renders a html with a block" do
+    {:safe, result} =
+      temple do
+        html(do: div())
+      end
+
+    assert result == ~s{<!DOCTYPE html><html><div></div></html>}
+  end
+
+  test "renders a html with attrs and a block" do
+    {:safe, result} =
+      temple do
+        html(class: "hello") do
+          div()
+        end
+      end
+
+    assert result == ~s{<!DOCTYPE html><html class="hello"><div></div></html>}
+  end
+
   for tag <- Temple.Tags.nonvoid_elements() do
     test "renders a #{tag}" do
       {:safe, result} =


### PR DESCRIPTION
Proposed fix for Issue #17 

Removed html from the list of nonvoid tags.  Implemented specifically
so the doctype declaration can be put in.  Not sure if this or adding
an if block to check the tag was a better solution.

Added tests for the html macro to the tests since it would no longer
show up in nonvoid_elements list.

mix test passes