### PR TITLE
Add support for component parameters

### DIFF
--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -144,7 +144,13 @@ defmodule Temple do
   #          </div>"}
   ```
   """
-  defmacro defcomponent(name, params \\ [], [do: _] = block) do
+  defmacro defcomponent(component, [do: _] = block) do
+    {name, params} =
+      case component do
+        {name, _, params} -> {name, params}
+        name -> {name, []}
+      end
+
     param = fn name ->
       Macro.var(name, __MODULE__)
     end

--- a/lib/temple/utils.ex
+++ b/lib/temple/utils.ex
@@ -88,6 +88,25 @@ defmodule Temple.Utils do
     |> Macro.prewalk(&Temple.Utils.insert_props(&1, props, inner))
   end
 
+  def __insert_params__(block, params) do
+    param_names =
+      Enum.map(params, fn {param_name, _} ->
+        param_name
+      end)
+
+    Macro.prewalk(block, fn
+      {var, _, _} = node ->
+        if var in param_names do
+          Keyword.get(params, var)
+        else
+          node
+        end
+
+      node ->
+        node
+    end)
+  end
+
   def doc_path(:html, el), do: "./tmp/docs/html/#{el}.txt"
   def doc_path(:svg, el), do: "./tmp/docs/svg/#{el}.txt"
 

--- a/lib/temple/utils.ex
+++ b/lib/temple/utils.ex
@@ -89,18 +89,9 @@ defmodule Temple.Utils do
   end
 
   def __insert_params__(block, params) do
-    param_names =
-      Enum.map(params, fn {param_name, _} ->
-        param_name
-      end)
-
     Macro.prewalk(block, fn
-      {var, _, _} = node ->
-        if var in param_names do
-          Keyword.get(params, var)
-        else
-          node
-        end
+      {var, _, _} = node when is_atom(var) ->
+        Keyword.get(params, var, node)
 
       node ->
         node

--- a/test/support/component.ex
+++ b/test/support/component.ex
@@ -13,6 +13,18 @@ defmodule Component do
     end
   end
 
+  defcomponent :takes_params, [foo, bar_baz, num] do
+    p do: text(foo)
+
+    case bar_baz do
+      :bar -> p do: text("bar")
+      :baz -> p do: text("baz")
+      _ -> nil
+    end
+
+    p do: text(num)
+  end
+
   defcomponent :arbitrary_code do
     num = 1..10 |> Enum.reduce(0, fn x, sum -> x + sum end)
 
@@ -55,12 +67,26 @@ defmodule Component do
     end
   end
 
+  defcomponent :params_with_props_and_block, [param] do
+    div id: param do
+      if param == @prop do
+        @children
+      end
+    end
+  end
+
   defcomponent :variable_as_prop do
     div id: @bob
   end
 
   defcomponent :variable_as_prop_with_block do
     div id: @bob do
+      @children
+    end
+  end
+
+  defcomponent :variable_as_param_with_block, [bob] do
+    div id: bob do
       @children
     end
   end

--- a/test/support/component.ex
+++ b/test/support/component.ex
@@ -13,7 +13,7 @@ defmodule Component do
     end
   end
 
-  defcomponent :takes_params, [foo, bar_baz, num] do
+  defcomponent takes_params(foo, bar_baz, num) do
     p do: text(foo)
 
     case bar_baz do
@@ -67,7 +67,7 @@ defmodule Component do
     end
   end
 
-  defcomponent :params_with_props_and_block, [param] do
+  defcomponent params_with_props_and_block(param) do
     div id: param do
       if param == @prop do
         @children
@@ -85,7 +85,7 @@ defmodule Component do
     end
   end
 
-  defcomponent :variable_as_param_with_block, [bob] do
+  defcomponent variable_as_param_with_block(bob) do
     div id: bob do
       @children
     end

--- a/test/temple_test.exs
+++ b/test/temple_test.exs
@@ -99,6 +99,47 @@ defmodule TempleTest do
       assert result == ~s{<div></div><span></span>}
     end
 
+    test "can pass arbitrary data as params" do
+      import Component
+
+      {:safe, result} =
+        temple do
+          takes_params("foo", :bar, 1)
+        end
+
+      assert result ==
+               ~s{<p>foo</p><p>bar</p><p>1</p>}
+    end
+
+    test "can pass a variable as a param" do
+      import Component
+
+      num = 3
+
+      {:safe, result} =
+        temple do
+          takes_params("foo", :bar, num)
+        end
+
+      assert result ==
+               ~s{<p>foo</p><p>bar</p><p>3</p>}
+    end
+
+    test "can pass a variable as a param to a component with a block" do
+      import Component
+
+      bob = "hi"
+
+      {:safe, result} =
+        temple do
+          variable_as_param_with_block bob do
+            div()
+          end
+        end
+
+      assert result == ~s{<div id="hi"><div></div></div>}
+    end
+
     test "can pass arbitrary data as props" do
       import Component
 
@@ -186,6 +227,32 @@ defmodule TempleTest do
         end
 
       assert result == ~s|<div id="hi"><div></div></div><div id="hi"><div></div></div>|
+    end
+
+    test "cann pass params and props with a block" do
+      import Component
+
+      {:safe, result} =
+        temple do
+          params_with_props_and_block :bar, prop: :bar do
+            span "foo"
+          end
+        end
+
+      assert result == ~s|<div id="bar"><span>foo</span></div>|
+    end
+
+    test "cann pass params and a map as props with a block" do
+      import Component
+
+      {:safe, result} =
+        temple do
+          params_with_props_and_block :baz, %{prop: :baz} do
+            span "foo"
+          end
+        end
+
+      assert result == ~s|<div id="baz"><span>foo</span></div>|
     end
   end
 end


### PR DESCRIPTION
Adds support for component params:

```elixir
defcomponent :heading, [title] do
  h1 title
  span "With " <> @props
end

temple do
  heading "Heading", props: "props"
end
```

I haven't done meta programming before, so there might be a better way to implement. Thanks for Temple!