### PR TITLE
Loosen the dependency on plug

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,6 @@ defmodule Temple.MixProject do
       {:ex_doc, "~> 0.0", only: [:dev], runtime: false},
       {:html_sanitize_ex, "~> 1.3", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.4", optional: true},
-      {:plug, "~> 1.7", optional: true},
       {:floki, "~> 0.23.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Temple.MixProject do
       {:ex_doc, "~> 0.0", only: [:dev], runtime: false},
       {:html_sanitize_ex, "~> 1.3", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.4", optional: true},
-      {:plug, "~> 1.8", optional: true},
+      {:plug, "~> 1.7", optional: true},
       {:floki, "~> 0.23.0", only: [:dev, :test], runtime: false}
     ]
   end


### PR DESCRIPTION
We could make it `only: [:dev, :test]` as well I think?

edit: I tried and it didn't work :/