### PR TITLE
Add eval

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 locals_without_parens = ~w[
   temple
+  eval
   html head title style script
   noscript template
   body section nav article aside h1 h2 h3 h4 h5 h6

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -11,7 +11,7 @@ defmodule Temple do
     sub sup i b u mark ruby rt rp bdi bdo span
     ins del
     iframe object video audio canvas
-    map 
+    map
     table caption colgroup tbody thead tfoot tr td th
     form fieldset legend label button select datalist optgroup
     option textarea output progress meter
@@ -98,6 +98,9 @@ defmodule Temple do
     # |> IO.inspect(label: :args, pretty: true, limit: :infinity, printable_limit: :infinity)
 
     case name do
+      :eval ->
+        Buffer.put(buffer, "<% " <> Macro.to_string(do_and_else[:do]) <> " %>")
+
       name when name in @nonvoid_elements ->
         Buffer.put(buffer, "<#{name}#{compile_attrs(args)}>")
         traverse(buffer, do_and_else[:do])

--- a/test/temple_test.exs
+++ b/test/temple_test.exs
@@ -35,6 +35,27 @@ defmodule TempleTest do
     assert result == ~s{<div class="hello">hifoo</div>}
   end
 
+  test "renders an eval do block as eex" do
+    result =
+      temple do
+        eval do
+          x = 1
+          y = 2
+          z = x + y
+          some_function(x, y, z)
+
+          if x == 1 do
+            :this
+          else
+            :that
+          end
+        end
+      end
+
+    assert result ==
+             ~s{<% (\n  x = 1\n  y = 2\n  z = x + y\n  some_function(x, y, z)\n  if(x == 1) do\n    :this\n  else\n    :that\n  end\n\n) %>}
+  end
+
   test "renders a variable text node as eex" do
     result =
       temple do


### PR DESCRIPTION
Currently all expressions are rendered with a `<%= ... %>` eex block. Sometimes it is useful to evaluate/execute some code in a `<% ... %>` block without displaying them. This PR introduces the `eval` do block to do exactly that. 

I am not very familiar with Elixir macros but this seems to get the job done.