### PR TITLE
Join attribute value with space if given as a list

### DIFF
--- a/lib/temple/parser.ex
+++ b/lib/temple/parser.ex
@@ -112,6 +112,10 @@ defmodule Temple.Parser do
             {_, _, _} = macro ->
               " " <> name <> "=\"<%= " <> Macro.to_string(macro) <> " %>\""
 
+            value when is_list(value) ->
+              value = value |> Enum.map(&to_string/1) |> Enum.join(" ")
+              " " <> name <> "=\"" <> to_string(value) <> "\""
+
             value ->
               " " <> name <> "=\"" <> to_string(value) <> "\""
           end


### PR DESCRIPTION
https://github.com/mhanberg/temple/blob/6fe46cbb4998477d76147fa95c9fd9c7841545ef/lib/temple/parser.ex#L111-L117

Would it hurt to match on lists, and join them with a space?

 ```exlixir
case value do 
   {_, _, _} = macro -> 
     " " <> name <> "=\"<%= " <> Macro.to_string(macro) <> " %>\"" 

  value when is_list(value) ->
    combined = value
      |> Enum.map(&to_string/1)
      |> Enum.join(" ")
    " " <> name <> "=\"" <> combined <> "\"" 

   value -> 
     " " <> name <> "=\"" <> to_string(value) <> "\"" 
 end 
```

It would allow for:

```
base = ~w(button inset)
specific = ~w(disabled)
div class: base ++ specific, to: "..." # <div class="button inset disabled"... instead of <div class="buttoninsetdisabled"...
```

I can only imagine the base behaviour is useful if you are doing something like

```
padding_name = "p-"
padding_amount = "3"
div class: [padding_name, padding_amount], do: "..."
```

But that seems pretty odd to write.