### PR TITLE
Align component model with HEEx/Surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@
 
 - Temple components are now compatible with HEEx/Surface components! Some small tweaks to the component implementation has made this possible. Please see the guides for more information.
 - Multiple instances of the same slot name can now be declared and then rendered inside the component (similar to HEEx and Surface).
+- You can now pass arbitrary data to slots, and it does not need to be a map or a keyword list. I don't think this is a breaking change, but please submit an issue if you notice it is.
+- Slot attributes. You can now pass data into a slot from the definition site and use it at the call site (inside the component).
 
 ### Breaking Changes
 
 - Rendering slots is now done by passing the assign with the slot name to the `slot` keyword instead of name as an atom. If this slot has multiple definitions, you can loop through them and render each one individually, or render them all at once. Please see the migration guide for more information.
+- The `:default` slot has been renamed to `:inner_block`. This is to be easily compatible with HEEx/Surface. Please see the migration guide for more information.
+- Capturing the data being passed into a slot is now defined using the `:let` attribute. Please see the migration guide for more information.
 
 ### 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Main
 
+### Enhancements
+
+- Temple components are now compatible with HEEx/Surface components! Some small tweaks to the component implementation has made this possible. Please see the guides for more information.
+- Multiple instances of the same slot name can now be declared and then rendered inside the component (similar to HEEx and Surface).
+
+### Breaking Changes
+
+- Rendering slots is now done by passing the assign with the slot name to the `slot` keyword instead of name as an atom. If this slot has multiple definitions, you can loop through them and render each one individually, or render them all at once. Please see the migration guide for more information.
+
 ### 0.10.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Temple components are simple to write and easy to use.
 
 Unlike normal partials, Temple components have the concept of "slots", which are similar [Vue](https://v3.vuejs.org/guide/component-slots.html#named-slots). You can also refer to HEEx and Surface for examples of templates that have the "slot" concept.
 
+Temple components are compatible with HEEx and Surface components and can be shared.
+
 Please see the [guides](https://hexdocs.pm/temple/components.html) for more details.
 
 ```elixir
@@ -77,15 +79,15 @@ defmodule MyAppWeb.Component do
     temple do
       section do
         div do
-          slot :header
+          slot @header
         end
 
         div do
-          slot :default
+          slot @inner_block
         end
 
         div do
-          slot :footer
+          slot @footer
         end
       end
     end

--- a/guides/components.md
+++ b/guides/components.md
@@ -145,8 +145,8 @@ def MyApp.CardExample do
         "This example demonstrates how to create components with multiple, named slots"
 
         slot :footer do
-          a href="#", class: "card-footer-item", do: "Footer Item 1"
-          a href="#", class: "card-footer-item", do: "Footer Item 2"
+          a href: "#", class: "card-footer-item", do: "Footer Item 1"
+          a href: "#", class: "card-footer-item", do: "Footer Item 2"
         end
       end
     end

--- a/guides/migrating/0.10-to-0.11.md
+++ b/guides/migrating/0.10-to-0.11.md
@@ -1,0 +1,95 @@
+# Migrating from 0.10 to 0.11
+
+Most of the changes in this release are related to tweaking Temple's component model to align with HEEx & Surface.
+
+## Rendering Slots
+
+Slots are now available as assigns in the component and are rendered as such.
+
+### Before
+
+```elixir
+def my_component(assign) do
+  temple do
+    span do
+      slot :a_slot
+    end
+  end
+end
+```
+
+### After
+
+```elixir
+def my_component(assign) do
+  temple do
+    span do
+      slot @a_slot
+    end
+  end
+end
+```
+
+## :default slot has been renamed to :inner_block
+
+The main body of a component has been renamed from `:default` to `:inner_block`.
+
+Note: The "after" example also includes the necessary change specified above.
+
+### Before
+
+```elixir
+def my_component(assign) do
+  temple do
+    span do
+      slot :default
+    end
+  end
+end
+```
+
+### After
+
+```elixir
+def my_component(assign) do
+  temple do
+    span do
+      slot @inner_block
+    end
+  end
+end
+```
+
+## Passing data into slots
+
+The syntax for capturing data being passed from the call site of a slot to the definition of a slot (or put another way, from the definition of a component to the call site of the component) has changed. 
+
+You now capture it as the value of the `:let` attribute on the slot definition.
+
+### Before
+
+```elixir
+def my_component(assign) do
+  temple do
+    c &my_component/1 do
+      slot :a_slot, %{some: value} do
+        "I'm using some #{value}"
+      end
+    end
+  end
+end
+```
+
+### After
+
+```elixir
+def my_component(assign) do
+  temple do
+    c &my_component/1 do
+      slot :a_slot, let: %{some: value} do
+        "I'm using some #{value}"
+      end
+    end
+  end
+end
+```

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -151,6 +151,8 @@ defmodule Temple do
   def __render_slot__(entries, argument) when is_list(entries) do
     assigns = %{}
 
+    _ = assigns
+
     temple do
       for entry <- entries do
         call_inner_block!(entry, argument)

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -149,6 +149,9 @@ defmodule Temple do
   end
 
   def __render_slot__(entries, argument) when is_list(entries) do
+    assigns = %{}
+    _ = assigns
+
     temple do
       for entry <- entries do
         call_inner_block!(entry, argument)

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -149,10 +149,6 @@ defmodule Temple do
   end
 
   def __render_slot__(entries, argument) when is_list(entries) do
-    assigns = %{}
-
-    _ = assigns
-
     temple do
       for entry <- entries do
         call_inner_block!(entry, argument)

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -149,6 +149,8 @@ defmodule Temple do
   end
 
   def __render_slot__(entries, argument) when is_list(entries) do
+    assigns = %{}
+
     temple do
       for entry <- entries do
         call_inner_block!(entry, argument)

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -162,7 +162,7 @@ defmodule Temple do
 
   defp call_inner_block!(entry, argument) do
     if !entry.inner_block do
-      message = "attempted to render slot <:#{entry.__slot__}> but the slot has no inner content"
+      message = "attempted to render slot #{entry.__slot__} but the slot has no inner content"
       raise RuntimeError, message
     end
 

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -93,6 +93,8 @@ defmodule Temple do
   <link href="/css/site.css">
   ```
   """
+  @doc false
+  def engine(), do: @engine
 
   defmacro temple(block) do
     opts = [engine: engine()]
@@ -104,10 +106,66 @@ defmodule Temple do
   end
 
   @doc false
-  def component(func, assigns) do
+  def component(func, assigns, _) do
     apply(func, [assigns])
   end
 
+  defmacro inner_block(_name, do: do_block) do
+    __inner_block__(do_block)
+  end
+
   @doc false
-  def engine(), do: @engine
+  def __inner_block__([{:->, meta, _} | _] = do_block) do
+    inner_fun = {:fn, meta, do_block}
+
+    quote do
+      fn arg ->
+        _ = var!(assigns)
+        unquote(inner_fun).(arg)
+      end
+    end
+  end
+
+  def __inner_block__(do_block) do
+    quote do
+      fn arg ->
+        _ = var!(assigns)
+        unquote(do_block)
+      end
+    end
+  end
+
+  defmacro render_slot(slot, arg) do
+    quote do
+      unquote(__MODULE__).__render_slot__(unquote(slot), unquote(arg))
+    end
+  end
+
+  @doc false
+  def __render_slot__([], _), do: nil
+
+  def __render_slot__([entry], argument) do
+    call_inner_block!(entry, argument)
+  end
+
+  def __render_slot__(entries, argument) when is_list(entries) do
+    temple do
+      for entry <- entries do
+        call_inner_block!(entry, argument)
+      end
+    end
+  end
+
+  def __render_slot__(entry, argument) when is_map(entry) do
+    entry.inner_block.(argument)
+  end
+
+  defp call_inner_block!(entry, argument) do
+    if !entry.inner_block do
+      message = "attempted to render slot <:#{entry.__slot__}> but the slot has no inner content"
+      raise RuntimeError, message
+    end
+
+    entry.inner_block.(argument)
+  end
 end

--- a/lib/temple/ast.ex
+++ b/lib/temple/ast.ex
@@ -2,17 +2,17 @@ defmodule Temple.Ast do
   @moduledoc false
 
   @type t ::
-          Temple.Parser.Empty.t()
-          | Temple.Parser.Text.t()
-          | Temple.Parser.Components.t()
-          | Temple.Parser.Slot.t()
-          | Temple.Parser.NonvoidElementsAliases.t()
-          | Temple.Parser.VoidElementsAliases.t()
-          | Temple.Parser.AnonymousFunctions.t()
-          | Temple.Parser.RightArrow.t()
-          | Temple.Parser.DoExpressions.t()
-          | Temple.Parser.Match.t()
-          | Temple.Parser.Default.t()
+          Temple.Ast.Empty.t()
+          | Temple.Ast.Text.t()
+          | Temple.Ast.Components.t()
+          | Temple.Ast.Slot.t()
+          | Temple.Ast.NonvoidElementsAliases.t()
+          | Temple.Ast.VoidElementsAliases.t()
+          | Temple.Ast.AnonymousFunctions.t()
+          | Temple.Ast.RightArrow.t()
+          | Temple.Ast.DoExpressions.t()
+          | Temple.Ast.Match.t()
+          | Temple.Ast.Default.t()
 
   def new(module, opts \\ []) do
     struct(module, opts)

--- a/lib/temple/ast/anonymous_functions.ex
+++ b/lib/temple/ast/anonymous_functions.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.AnonymousFunctions do
+defmodule Temple.Ast.AnonymousFunctions do
   @moduledoc false
   @behaviour Temple.Parser
 
@@ -11,7 +11,7 @@ defmodule Temple.Parser.AnonymousFunctions do
 
   @impl true
   def applicable?({_, _, args}) do
-    import Temple.Parser.Utils, only: [split_args: 1]
+    import Temple.Ast.Utils, only: [split_args: 1]
 
     args
     |> split_args()
@@ -23,9 +23,9 @@ defmodule Temple.Parser.AnonymousFunctions do
 
   @impl true
   def run({_name, _, args} = expression) do
-    {_do_and_else, args} = Temple.Parser.Utils.split_args(args)
+    {_do_and_else, args} = Temple.Ast.Utils.split_args(args)
 
-    {_args, func_arg, _args2} = Temple.Parser.Utils.split_on_fn(args, {[], nil, []})
+    {_args, func_arg, _args2} = Temple.Ast.Utils.split_on_fn(args, {[], nil, []})
 
     {_func, _, [{_arrow, _, [[{_arg, _, _}], block]}]} = func_arg
 

--- a/lib/temple/ast/components.ex
+++ b/lib/temple/ast/components.ex
@@ -40,7 +40,8 @@ defmodule Temple.Ast.Components do
               if is_nil(slot) do
                 {node, {component_function, named_slots}}
               else
-                new_slot = {name, %{assigns: assigns, slot: slot}}
+                {assigns, attributes} = Keyword.pop(assigns, :let)
+                new_slot = {name, %{assigns: assigns, slot: slot, attributes: attributes}}
                 {nil, {component_function, named_slots ++ [new_slot]}}
               end
 
@@ -66,12 +67,13 @@ defmodule Temple.Ast.Components do
       end
 
     slots =
-      for {name, %{slot: slot, assigns: assigns}} <- named_slots do
+      for {name, %{slot: slot, assigns: assigns, attributes: attributes}} <- named_slots do
         Temple.Ast.new(
           Temple.Ast.Slottable,
           name: name,
           content: Temple.Parser.parse(slot),
-          assigns: assigns
+          assigns: assigns,
+          attributes: attributes
         )
       end
 

--- a/lib/temple/ast/components.ex
+++ b/lib/temple/ast/components.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Components do
+defmodule Temple.Ast.Components do
   @moduledoc false
   @behaviour Temple.Parser
 
@@ -21,9 +21,9 @@ defmodule Temple.Parser.Components do
   def run({:c, _meta, [component_function | args]}) do
     {do_and_else, args} =
       args
-      |> Temple.Parser.Utils.split_args()
+      |> Temple.Ast.Utils.split_args()
 
-    {do_and_else, assigns} = Temple.Parser.Utils.consolidate_blocks(do_and_else, args)
+    {do_and_else, assigns} = Temple.Ast.Utils.consolidate_blocks(do_and_else, args)
 
     {default_slot, {_, named_slots}} =
       if children = do_and_else[:do] do
@@ -58,7 +58,7 @@ defmodule Temple.Parser.Components do
       else
         [
           Temple.Ast.new(
-            Temple.Parser.Slottable,
+            Temple.Ast.Slottable,
             name: :inner_block,
             content: Temple.Parser.parse(default_slot)
           )
@@ -68,7 +68,7 @@ defmodule Temple.Parser.Components do
     slots =
       for {name, %{slot: slot, assigns: assigns}} <- named_slots do
         Temple.Ast.new(
-          Temple.Parser.Slottable,
+          Temple.Ast.Slottable,
           name: name,
           content: Temple.Parser.parse(slot),
           assigns: assigns

--- a/lib/temple/ast/components.ex
+++ b/lib/temple/ast/components.ex
@@ -40,7 +40,7 @@ defmodule Temple.Ast.Components do
               if is_nil(slot) do
                 {node, {component_function, named_slots}}
               else
-                {assigns, attributes} = Keyword.pop(assigns, :let)
+                {assigns, attributes} = Keyword.pop(assigns || [], :let)
                 new_slot = {name, %{assigns: assigns, slot: slot, attributes: attributes}}
                 {nil, {component_function, named_slots ++ [new_slot]}}
               end

--- a/lib/temple/ast/default.ex
+++ b/lib/temple/ast/default.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Default do
+defmodule Temple.Ast.Default do
   @moduledoc false
   @behaviour Temple.Parser
 

--- a/lib/temple/ast/do_expressions.ex
+++ b/lib/temple/ast/do_expressions.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.DoExpressions do
+defmodule Temple.Ast.DoExpressions do
   @moduledoc false
   @behaviour Temple.Parser
 
@@ -18,7 +18,7 @@ defmodule Temple.Parser.DoExpressions do
 
   @impl true
   def run({name, meta, args}) do
-    {do_and_else, args} = Temple.Parser.Utils.split_args(args)
+    {do_and_else, args} = Temple.Ast.Utils.split_args(args)
 
     do_body = Temple.Parser.parse(do_and_else[:do])
 

--- a/lib/temple/ast/element_list.ex
+++ b/lib/temple/ast/element_list.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.ElementList do
+defmodule Temple.Ast.ElementList do
   @moduledoc false
 
   @behaviour Temple.Parser

--- a/lib/temple/ast/empty.ex
+++ b/lib/temple/ast/empty.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Empty do
+defmodule Temple.Ast.Empty do
   @moduledoc false
 
   use TypedStruct

--- a/lib/temple/ast/match.ex
+++ b/lib/temple/ast/match.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Match do
+defmodule Temple.Ast.Match do
   @moduledoc false
   @behaviour Temple.Parser
 

--- a/lib/temple/ast/nonvoid_elements_aliases.ex
+++ b/lib/temple/ast/nonvoid_elements_aliases.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.NonvoidElementsAliases do
+defmodule Temple.Ast.NonvoidElementsAliases do
   @moduledoc false
   @behaviour Temple.Parser
 
@@ -24,9 +24,9 @@ defmodule Temple.Parser.NonvoidElementsAliases do
   def run({name, meta, args}) do
     name = Parser.nonvoid_elements_lookup()[name]
 
-    {do_and_else, args} = Temple.Parser.Utils.split_args(args)
+    {do_and_else, args} = Temple.Ast.Utils.split_args(args)
 
-    {do_and_else, args} = Temple.Parser.Utils.consolidate_blocks(do_and_else, args)
+    {do_and_else, args} = Temple.Ast.Utils.consolidate_blocks(do_and_else, args)
 
     children = Temple.Parser.parse(do_and_else[:do])
 
@@ -35,7 +35,7 @@ defmodule Temple.Parser.NonvoidElementsAliases do
       attrs: args,
       meta: %{whitespace: whitespace(meta)},
       children:
-        Temple.Ast.new(Temple.Parser.ElementList,
+        Temple.Ast.new(Temple.Ast.ElementList,
           children: children,
           whitespace: whitespace(meta)
         )

--- a/lib/temple/ast/right_arrow.ex
+++ b/lib/temple/ast/right_arrow.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.RightArrow do
+defmodule Temple.Ast.RightArrow do
   @moduledoc false
 
   @behaviour Temple.Parser

--- a/lib/temple/ast/slot.ex
+++ b/lib/temple/ast/slot.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Slot do
+defmodule Temple.Ast.Slot do
   @moduledoc false
   @behaviour Temple.Parser
   use TypedStruct

--- a/lib/temple/ast/slottable.ex
+++ b/lib/temple/ast/slottable.ex
@@ -5,7 +5,7 @@ defmodule Temple.Ast.Slottable do
 
   typedstruct do
     field :content, [Temple.Ast.t()]
-    field :assigns, Macro.t()
+    field :parameter, Macro.t()
     field :name, atom()
     field :attributes, Macro.t(), default: []
   end

--- a/lib/temple/ast/slottable.ex
+++ b/lib/temple/ast/slottable.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Slottable do
+defmodule Temple.Ast.Slottable do
   @moduledoc false
 
   use TypedStruct

--- a/lib/temple/ast/slottable.ex
+++ b/lib/temple/ast/slottable.ex
@@ -4,8 +4,9 @@ defmodule Temple.Ast.Slottable do
   use TypedStruct
 
   typedstruct do
-    field :content, any()
-    field :assigns, map()
+    field :content, [Temple.Ast.t()]
+    field :assigns, Macro.t()
     field :name, atom()
+    field :attributes, Macro.t(), default: []
   end
 end

--- a/lib/temple/ast/temple_namespace_nonvoid.ex
+++ b/lib/temple/ast/temple_namespace_nonvoid.ex
@@ -1,10 +1,12 @@
-defmodule Temple.Parser.TempleNamespaceVoid do
+defmodule Temple.Ast.TempleNamespaceNonvoid do
   @moduledoc false
   @behaviour Temple.Parser
 
+  alias Temple.Parser
+
   @impl true
   def applicable?({{:., _, [{:__aliases__, _, [:Temple]}, name]}, _meta, _args}) do
-    name in Temple.Parser.void_elements_aliases()
+    name in Parser.nonvoid_elements_aliases()
   end
 
   def applicable?(_), do: false
@@ -12,7 +14,6 @@ defmodule Temple.Parser.TempleNamespaceVoid do
   @impl true
   def run({name, meta, args}) do
     {:., _, [{:__aliases__, _, [:Temple]}, name]} = name
-
-    Temple.Parser.VoidElementsAliases.run({name, meta, args})
+    Temple.Ast.NonvoidElementsAliases.run({name, meta, args})
   end
 end

--- a/lib/temple/ast/temple_namespace_void.ex
+++ b/lib/temple/ast/temple_namespace_void.ex
@@ -1,12 +1,10 @@
-defmodule Temple.Parser.TempleNamespaceNonvoid do
+defmodule Temple.Ast.TempleNamespaceVoid do
   @moduledoc false
   @behaviour Temple.Parser
 
-  alias Temple.Parser
-
   @impl true
   def applicable?({{:., _, [{:__aliases__, _, [:Temple]}, name]}, _meta, _args}) do
-    name in Parser.nonvoid_elements_aliases()
+    name in Temple.Parser.void_elements_aliases()
   end
 
   def applicable?(_), do: false
@@ -14,6 +12,7 @@ defmodule Temple.Parser.TempleNamespaceNonvoid do
   @impl true
   def run({name, meta, args}) do
     {:., _, [{:__aliases__, _, [:Temple]}, name]} = name
-    Temple.Parser.NonvoidElementsAliases.run({name, meta, args})
+
+    Temple.Ast.VoidElementsAliases.run({name, meta, args})
   end
 end

--- a/lib/temple/ast/text.ex
+++ b/lib/temple/ast/text.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Text do
+defmodule Temple.Ast.Text do
   @moduledoc false
   @behaviour Temple.Parser
 

--- a/lib/temple/ast/utils.ex
+++ b/lib/temple/ast/utils.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.Utils do
+defmodule Temple.Ast.Utils do
   @moduledoc false
 
   def snake_to_kebab(stringable),
@@ -25,7 +25,7 @@ defmodule Temple.Parser.Utils do
             [{:text, " " <> name <> "=\"" <> to_string(value) <> "\""} | acc]
           else
             true ->
-              nodes = Temple.Parser.Utils.build_attr(name, value)
+              nodes = Temple.Ast.Utils.build_attr(name, value)
               Enum.reverse(nodes) ++ acc
           end
       end

--- a/lib/temple/ast/void_elements_aliases.ex
+++ b/lib/temple/ast/void_elements_aliases.ex
@@ -1,4 +1,4 @@
-defmodule Temple.Parser.VoidElementsAliases do
+defmodule Temple.Ast.VoidElementsAliases do
   @moduledoc false
   @behaviour Temple.Parser
 
@@ -19,7 +19,7 @@ defmodule Temple.Parser.VoidElementsAliases do
   @impl true
   def run({name, _, args}) do
     args =
-      case Temple.Parser.Utils.split_args(args) do
+      case Temple.Ast.Utils.split_args(args) do
         {_, [args]} when is_list(args) ->
           args
 

--- a/lib/temple/parser.ex
+++ b/lib/temple/parser.ex
@@ -1,19 +1,19 @@
 defmodule Temple.Parser do
   @moduledoc false
 
-  alias Temple.Parser.AnonymousFunctions
-  alias Temple.Parser.Components
-  alias Temple.Parser.Default
-  alias Temple.Parser.DoExpressions
-  alias Temple.Parser.Empty
-  alias Temple.Parser.Match
-  alias Temple.Parser.NonvoidElementsAliases
-  alias Temple.Parser.RightArrow
-  alias Temple.Parser.Slot
-  alias Temple.Parser.TempleNamespaceNonvoid
-  alias Temple.Parser.TempleNamespaceVoid
-  alias Temple.Parser.Text
-  alias Temple.Parser.VoidElementsAliases
+  alias Temple.Ast.AnonymousFunctions
+  alias Temple.Ast.Components
+  alias Temple.Ast.Default
+  alias Temple.Ast.DoExpressions
+  alias Temple.Ast.Empty
+  alias Temple.Ast.Match
+  alias Temple.Ast.NonvoidElementsAliases
+  alias Temple.Ast.RightArrow
+  alias Temple.Ast.Slot
+  alias Temple.Ast.TempleNamespaceNonvoid
+  alias Temple.Ast.TempleNamespaceVoid
+  alias Temple.Ast.Text
+  alias Temple.Ast.VoidElementsAliases
 
   @aliases Application.compile_env(:temple, :aliases, [])
 

--- a/lib/temple/parser/components.ex
+++ b/lib/temple/parser/components.ex
@@ -60,7 +60,7 @@ defmodule Temple.Parser.Components do
         [
           Temple.Ast.new(
             Temple.Parser.Slottable,
-            name: :default,
+            name: :inner_block,
             content: Temple.Parser.parse(default_slot)
           )
         ]

--- a/lib/temple/parser/components.ex
+++ b/lib/temple/parser/components.ex
@@ -36,7 +36,7 @@ defmodule Temple.Parser.Components do
               {node, {name, named_slots}}
 
             {:slot, _, [name | args]} = node, {^component_function, named_slots} ->
-              {assigns, slot} = split_assigns_and_children(args, Macro.escape(%{}))
+              {assigns, slot} = split_assigns_and_children(args, nil)
 
               if is_nil(slot) do
                 {node, {component_function, named_slots}}

--- a/lib/temple/parser/components.ex
+++ b/lib/temple/parser/components.ex
@@ -7,7 +7,6 @@ defmodule Temple.Parser.Components do
   typedstruct do
     field :function, function()
     field :assigns, map()
-    field :children, [map()]
     field :slots, [function()]
   end
 

--- a/lib/temple/parser/slottable.ex
+++ b/lib/temple/parser/slottable.ex
@@ -5,7 +5,7 @@ defmodule Temple.Parser.Slottable do
 
   typedstruct do
     field :content, any()
-    field :assigns, map(), default: Macro.escape(%{})
+    field :assigns, map()
     field :name, atom()
   end
 end

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -116,7 +116,7 @@ defmodule Temple.Renderer do
         component(
           unquote(function),
           unquote(component_arguments),
-          {__MODULE__, __ENV__.function, __ENV__.file, nil}
+          {__MODULE__, __ENV__.function, __ENV__.file, __ENV__.line}
         )
       end
 

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -74,7 +74,6 @@ defmodule Temple.Renderer do
   def render(buffer, state, %Components{
         function: function,
         assigns: assigns,
-        # children: children,
         slots: slots
       }) do
     slot_quotes =

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -78,7 +78,7 @@ defmodule Temple.Renderer do
         slots: slots
       }) do
     slot_quotes =
-      Enum.group_by(slots, & &1.name, fn slot ->
+      Enum.group_by(slots, & &1.name, fn %Temple.Parser.Slottable{} = slot ->
         slot_buffer = state.engine.handle_begin(buffer)
 
         slot_buffer =
@@ -92,7 +92,7 @@ defmodule Temple.Renderer do
         inner_block =
           quote do
             inner_block unquote(slot.name) do
-              unquote(slot.assigns) ->
+              unquote(slot.assigns || quote(do: _)) ->
                 unquote(ast)
             end
           end
@@ -126,7 +126,7 @@ defmodule Temple.Renderer do
   def render(buffer, state, %Slot{} = ast) do
     render_slot_func =
       quote do
-        render_slot(var!(assigns)[unquote(ast.name)], Map.new(unquote(ast.args)))
+        render_slot(unquote(ast.name), unquote(ast.args))
       end
 
     state.engine.handle_expr(buffer, "=", render_slot_func)

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -74,7 +74,7 @@ defmodule Temple.Renderer do
 
   def render(buffer, state, %Components{
         function: function,
-        assigns: assigns,
+        arguments: arguments,
         slots: slots
       }) do
     slot_quotes =
@@ -92,7 +92,7 @@ defmodule Temple.Renderer do
         inner_block =
           quote do
             inner_block unquote(slot.name) do
-              unquote(slot.assigns || quote(do: _)) ->
+              unquote(slot.parameter || quote(do: _)) ->
                 unquote(ast)
             end
           end
@@ -104,9 +104,9 @@ defmodule Temple.Renderer do
          ] ++ slot.attributes}
       end)
 
-    assigns =
+    component_arguments =
       {:%{}, [],
-       assigns
+       arguments
        |> Map.new()
        |> Map.merge(slot_quotes)
        |> Enum.to_list()}
@@ -115,7 +115,7 @@ defmodule Temple.Renderer do
       quote do
         component(
           unquote(function),
-          unquote(assigns),
+          unquote(component_arguments),
           {__MODULE__, __ENV__.function, __ENV__.file, nil}
         )
       end

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -101,7 +101,7 @@ defmodule Temple.Renderer do
          [
            __slot__: slot.name,
            inner_block: inner_block
-         ]}
+         ] ++ slot.attributes}
       end)
 
     assigns =

--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -1,20 +1,21 @@
 defmodule Temple.Renderer do
   @moduledoc false
 
-  alias Temple.Parser.ElementList
-  alias Temple.Parser.Text
-  alias Temple.Parser.Components
-  alias Temple.Parser.Slot
-  alias Temple.Parser.NonvoidElementsAliases
-  alias Temple.Parser.VoidElementsAliases
-  alias Temple.Parser.AnonymousFunctions
-  alias Temple.Parser.RightArrow
-  alias Temple.Parser.DoExpressions
-  alias Temple.Parser.Match
-  alias Temple.Parser.Default
-  alias Temple.Parser.Empty
+  alias Temple.Ast.ElementList
+  alias Temple.Ast.Text
+  alias Temple.Ast.Components
+  alias Temple.Ast.Slot
+  alias Temple.Ast.Slottable
+  alias Temple.Ast.NonvoidElementsAliases
+  alias Temple.Ast.VoidElementsAliases
+  alias Temple.Ast.AnonymousFunctions
+  alias Temple.Ast.RightArrow
+  alias Temple.Ast.DoExpressions
+  alias Temple.Ast.Match
+  alias Temple.Ast.Default
+  alias Temple.Ast.Empty
 
-  alias Temple.Parser.Utils
+  alias Temple.Ast.Utils
 
   @default_engine EEx.SmartEngine
 
@@ -23,7 +24,7 @@ defmodule Temple.Renderer do
     |> Temple.Parser.parse()
     |> Temple.Renderer.render(opts)
 
-    # |> Temple.Parser.Utils.inspect_ast()
+    # |> Temple.Ast.Utils.inspect_ast()
   end
 
   def render(asts, opts \\ [])
@@ -77,7 +78,7 @@ defmodule Temple.Renderer do
         slots: slots
       }) do
     slot_quotes =
-      Enum.group_by(slots, & &1.name, fn %Temple.Parser.Slottable{} = slot ->
+      Enum.group_by(slots, & &1.name, fn %Slottable{} = slot ->
         slot_buffer = state.engine.handle_begin(buffer)
 
         slot_buffer =
@@ -233,7 +234,7 @@ defmodule Temple.Renderer do
     {name, meta, args} = ast.elixir_ast
 
     {args, {func, fmeta, [{arrow, arrowmeta, [first, _block]}]}, args2} =
-      Temple.Parser.Utils.split_on_fn(args, {[], nil, []})
+      Temple.Ast.Utils.split_on_fn(args, {[], nil, []})
 
     full_ast =
       {name, meta, args ++ [{func, fmeta, [{arrow, arrowmeta, [first, inner_quoted]}]}] ++ args2}

--- a/test/parser/anonymous_functions_test.exs
+++ b/test/parser/anonymous_functions_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.AnonymousFunctionsTest do
+defmodule Temple.Ast.AnonymousFunctionsTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.AnonymousFunctions
+  alias Temple.Ast.AnonymousFunctions
 
   describe "applicable?/1" do
     test "returns true when the node contains an anonymous function as an argument to a function" do
@@ -57,7 +57,7 @@ defmodule Temple.Parser.AnonymousFunctionsTest do
       assert %AnonymousFunctions{
                elixir_ast: _,
                children: [
-                 %Temple.Parser.Default{
+                 %Temple.Ast.Default{
                    elixir_ast: ^expected_child
                  }
                ]

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -111,7 +111,7 @@ defmodule Temple.Ast.ComponentsTest do
       raw_ast =
         quote do
           c unquote(func), foo: :bar do
-            slot :foo, %{form: form} do
+            slot :foo, let: %{form: form} do
               "in the slot"
             end
           end
@@ -132,6 +132,32 @@ defmodule Temple.Ast.ComponentsTest do
              } = ast
     end
 
+    test "slot attributes", %{func: func} do
+      raw_ast =
+        quote do
+          c unquote(func), foo: :bar do
+            slot :foo, let: %{form: form}, label: the_label do
+              "in the slot"
+            end
+          end
+        end
+
+      ast = Components.run(raw_ast)
+
+      assert %Components{
+               function: ^func,
+               assigns: [foo: :bar],
+               slots: [
+                 %Slottable{
+                   name: :foo,
+                   content: [%Temple.Ast.Text{}],
+                   assigns: {:%{}, _, [form: _]},
+                   attributes: [label: {:the_label, [], Temple.Ast.ComponentsTest}]
+                 }
+               ]
+             } = ast
+    end
+
     test "slots should only be assigned to the component root" do
       card = quote do: &Card.render/1
       footer = quote do: &Card.Footer.render/1
@@ -144,7 +170,7 @@ defmodule Temple.Ast.ComponentsTest do
               c unquote(list), socials: @user.socials do
                 "hello"
 
-                slot :foo, %{text: text, url: url} do
+                slot :foo, let: %{text: text, url: url} do
                   a class: "text-blue-500 hover:underline", href: url do
                     text
                   end

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -1,5 +1,5 @@
 defmodule Temple.Ast.ComponentsTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias Temple.Ast.Components
   alias Temple.Ast.Slottable
 

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.ComponentsTest do
+defmodule Temple.Ast.ComponentsTest do
   use ExUnit.Case, async: false
-  alias Temple.Parser.Components
-  alias Temple.Parser.Slottable
+  alias Temple.Ast.Components
+  alias Temple.Ast.Slottable
 
   describe "applicable?/1" do
     test "runs when using the `c` ast with a block" do
@@ -125,7 +125,7 @@ defmodule Temple.Parser.ComponentsTest do
                slots: [
                  %Slottable{
                    name: :foo,
-                   content: [%Temple.Parser.Text{}],
+                   content: [%Temple.Ast.Text{}],
                    assigns: {:%{}, _, [form: _]}
                  }
                ]
@@ -157,7 +157,7 @@ defmodule Temple.Parser.ComponentsTest do
       ast = Components.run(raw_ast)
 
       assert [
-               %Temple.Parser.Slottable{
+               %Slottable{
                  name: :inner_block,
                  assigns: nil
                }
@@ -165,11 +165,11 @@ defmodule Temple.Parser.ComponentsTest do
 
       assert %Components{
                slots: [
-                 %Temple.Parser.Slottable{
+                 %Slottable{
                    content: [
                      %Components{
                        slots: [
-                         %Temple.Parser.Slottable{
+                         %Slottable{
                            content: [
                              %Components{
                                slots: [

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -161,7 +161,7 @@ defmodule Temple.Parser.ComponentsTest do
 
       assert [
                %Temple.Parser.Slottable{
-                 name: :default,
+                 name: :inner_block,
                  assigns: {:%{}, [], []}
                }
              ] = ast.slots
@@ -177,7 +177,7 @@ defmodule Temple.Parser.ComponentsTest do
                              %Components{
                                slots: [
                                  %Slottable{
-                                   name: :default
+                                   name: :inner_block
                                  },
                                  %Slottable{
                                    name: :foo

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -106,8 +106,7 @@ defmodule Temple.Parser.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar],
-               children: []
+               assigns: [foo: :bar]
              } = ast
     end
 
@@ -132,8 +131,7 @@ defmodule Temple.Parser.ComponentsTest do
                    content: [%Temple.Parser.Text{}],
                    assigns: {:%{}, _, [form: _]}
                  }
-               ],
-               children: []
+               ]
              } = ast
     end
 
@@ -149,7 +147,7 @@ defmodule Temple.Parser.ComponentsTest do
               c unquote(list), socials: @user.socials do
                 "hello"
 
-                slot :default, %{text: text, url: url} do
+                slot :foo, %{text: text, url: url} do
                   a class: "text-blue-500 hover:underline", href: url do
                     text
                   end
@@ -161,16 +159,32 @@ defmodule Temple.Parser.ComponentsTest do
 
       ast = Components.run(raw_ast)
 
-      assert Kernel.==(ast.slots, [])
+      assert [
+               %Temple.Parser.Slottable{
+                 name: :default,
+                 assigns: {:%{}, [], []}
+               }
+             ] = ast.slots
 
       assert %Components{
-               children: [
-                 %Components{
-                   children: [
+               slots: [
+                 %Temple.Parser.Slottable{
+                   content: [
                      %Components{
                        slots: [
-                         %Slottable{
-                           name: :default
+                         %Temple.Parser.Slottable{
+                           content: [
+                             %Components{
+                               slots: [
+                                 %Slottable{
+                                   name: :default
+                                 },
+                                 %Slottable{
+                                   name: :foo
+                                 }
+                               ]
+                             }
+                           ]
                          }
                        ]
                      }

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -57,7 +57,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [],
+               assigns: []
              } = ast
     end
 
@@ -71,7 +71,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar],
+               assigns: [foo: :bar]
              } = ast
     end
 
@@ -89,7 +89,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar],
+               assigns: [foo: :bar]
              } = ast
     end
 

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -58,7 +58,6 @@ defmodule Temple.Parser.ComponentsTest do
       assert %Components{
                function: ^func,
                assigns: [],
-               children: _
              } = ast
     end
 
@@ -73,7 +72,6 @@ defmodule Temple.Parser.ComponentsTest do
       assert %Components{
                function: ^func,
                assigns: [foo: :bar],
-               children: _
              } = ast
     end
 
@@ -92,7 +90,6 @@ defmodule Temple.Parser.ComponentsTest do
       assert %Components{
                function: ^func,
                assigns: [foo: :bar],
-               children: _
              } = ast
     end
 

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -57,7 +57,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: []
+               arguments: []
              } = ast
     end
 
@@ -71,7 +71,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar]
+               arguments: [foo: :bar]
              } = ast
     end
 
@@ -89,7 +89,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar]
+               arguments: [foo: :bar]
              } = ast
     end
 
@@ -103,7 +103,7 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar]
+               arguments: [foo: :bar]
              } = ast
     end
 
@@ -121,12 +121,12 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar],
+               arguments: [foo: :bar],
                slots: [
                  %Slottable{
                    name: :foo,
                    content: [%Temple.Ast.Text{}],
-                   assigns: {:%{}, _, [form: _]}
+                   parameter: {:%{}, _, [form: _]}
                  }
                ]
              } = ast
@@ -146,12 +146,12 @@ defmodule Temple.Ast.ComponentsTest do
 
       assert %Components{
                function: ^func,
-               assigns: [foo: :bar],
+               arguments: [foo: :bar],
                slots: [
                  %Slottable{
                    name: :foo,
                    content: [%Temple.Ast.Text{}],
-                   assigns: {:%{}, _, [form: _]},
+                   parameter: {:%{}, _, [form: _]},
                    attributes: [label: {:the_label, [], Temple.Ast.ComponentsTest}]
                  }
                ]
@@ -185,7 +185,7 @@ defmodule Temple.Ast.ComponentsTest do
       assert [
                %Slottable{
                  name: :inner_block,
-                 assigns: nil
+                 parameter: nil
                }
              ] = ast.slots
 

--- a/test/parser/components_test.exs
+++ b/test/parser/components_test.exs
@@ -162,7 +162,7 @@ defmodule Temple.Parser.ComponentsTest do
       assert [
                %Temple.Parser.Slottable{
                  name: :inner_block,
-                 assigns: {:%{}, [], []}
+                 assigns: nil
                }
              ] = ast.slots
 

--- a/test/parser/default_test.exs
+++ b/test/parser/default_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.DefaultTest do
+defmodule Temple.Ast.DefaultTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.Default
+  alias Temple.Ast.Default
 
   describe "applicable?/1" do
     test "returns true when the node is an elixir expression" do

--- a/test/parser/do_expressions_test.exs
+++ b/test/parser/do_expressions_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.DoExpressionsTest do
+defmodule Temple.Ast.DoExpressionsTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.DoExpressions
+  alias Temple.Ast.DoExpressions
 
   describe "applicable?/1" do
     test "returns true when the node contains a do expression" do
@@ -30,7 +30,7 @@ defmodule Temple.Parser.DoExpressionsTest do
       assert %DoExpressions{
                elixir_ast: _,
                children: [
-                 [%Temple.Parser.Text{text: "bob"}],
+                 [%Temple.Ast.Text{text: "bob"}],
                  nil
                ]
              } = ast

--- a/test/parser/empty_test.exs
+++ b/test/parser/empty_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.EmptyTest do
+defmodule Temple.Ast.EmptyTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.Empty
+  alias Temple.Ast.Empty
 
   describe "applicable?/1" do
     test "returns true when the node is non-content" do

--- a/test/parser/match_test.exs
+++ b/test/parser/match_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.MatchTest do
+defmodule Temple.Ast.MatchTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.Match
+  alias Temple.Ast.Match
 
   describe "applicable?/1" do
     test "returns true when the node is an elixir match expression" do

--- a/test/parser/nonvoid_elements_aliases_test.exs
+++ b/test/parser/nonvoid_elements_aliases_test.exs
@@ -1,8 +1,9 @@
-defmodule Temple.Parser.NonvoidElementsAliasesTest do
+defmodule Temple.Ast.NonvoidElementsAliasesTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.NonvoidElementsAliases
-  alias Temple.Parser.ElementList
+  alias Temple.Ast.NonvoidElementsAliases
+  alias Temple.Ast.ElementList
+  alias Temple.Ast.Text
 
   describe "applicable?/1" do
     test "returns true when the node is a nonvoid element or alias" do
@@ -74,7 +75,7 @@ defmodule Temple.Parser.NonvoidElementsAliasesTest do
                            name: "option",
                            children: %ElementList{
                              children: [
-                               %Temple.Parser.Text{text: "foo"}
+                               %Text{text: "foo"}
                              ]
                            }
                          }

--- a/test/parser/right_arrow_test.exs
+++ b/test/parser/right_arrow_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.RightArrowTest do
+defmodule Temple.Ast.RightArrowTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.RightArrow
+  alias Temple.Ast.RightArrow
 
   describe "applicable?/1" do
     test "returns true when the node contains a right arrow" do
@@ -52,7 +52,7 @@ defmodule Temple.Parser.RightArrowTest do
       assert %RightArrow{
                elixir_ast: {:->, [newlines: 1], [[:bing]]},
                children: [
-                 %Temple.Parser.Default{
+                 %Temple.Ast.Default{
                    elixir_ast: ^bong
                  }
                ]

--- a/test/parser/slot_test.exs
+++ b/test/parser/slot_test.exs
@@ -1,5 +1,5 @@
 defmodule Temple.Ast.SlotTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias Temple.Ast.Slot
 
   describe "applicable?/1" do

--- a/test/parser/slot_test.exs
+++ b/test/parser/slot_test.exs
@@ -1,6 +1,6 @@
-defmodule Temple.Parser.SlotTest do
+defmodule Temple.Ast.SlotTest do
   use ExUnit.Case, async: false
-  alias Temple.Parser.Slot
+  alias Temple.Ast.Slot
 
   describe "applicable?/1" do
     test "runs when using the `c` ast with a block" do

--- a/test/parser/temple_namespace_nonvoid_test.exs
+++ b/test/parser/temple_namespace_nonvoid_test.exs
@@ -1,8 +1,10 @@
-defmodule Temple.Parser.TempleNamespaceNonvoidTest do
+defmodule Temple.Ast.TempleNamespaceNonvoidTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.NonvoidElementsAliases
-  alias Temple.Parser.TempleNamespaceNonvoid
+  alias Temple.Ast.ElementList
+  alias Temple.Ast.NonvoidElementsAliases
+  alias Temple.Ast.TempleNamespaceNonvoid
+  alias Temple.Ast.Text
 
   describe "applicable?/1" do
     test "returns true when the node is a Temple aliased nonvoid element" do
@@ -50,8 +52,8 @@ defmodule Temple.Parser.TempleNamespaceNonvoidTest do
       assert %NonvoidElementsAliases{
                name: "div",
                attrs: [class: "foo", id: {:var, [], _}],
-               children: %Temple.Parser.ElementList{
-                 children: [%Temple.Parser.Text{text: "foo"}],
+               children: %ElementList{
+                 children: [%Text{text: "foo"}],
                  whitespace: :loose
                }
              } = ast

--- a/test/parser/temple_namespace_void_test.exs
+++ b/test/parser/temple_namespace_void_test.exs
@@ -1,8 +1,8 @@
-defmodule Temple.Parser.TempleNamespaceVoidTest do
+defmodule Temple.Ast.TempleNamespaceVoidTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.TempleNamespaceVoid
-  alias Temple.Parser.VoidElementsAliases
+  alias Temple.Ast.TempleNamespaceVoid
+  alias Temple.Ast.VoidElementsAliases
 
   describe "applicable?/1" do
     test "returns true when the node is a Temple aliased nonvoid element" do

--- a/test/parser/text_test.exs
+++ b/test/parser/text_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.TextTest do
+defmodule Temple.Ast.TextTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.Text
+  alias Temple.Ast.Text
 
   describe "applicable?/1" do
     test "returns true when the node is a string literal" do

--- a/test/parser/utils_test.exs
+++ b/test/parser/utils_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.UtilsTest do
+defmodule Temple.Ast.UtilsTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.Utils
+  alias Temple.Ast.Utils
 
   describe "compile_attrs/1" do
     test "returns a list of text nodes for static attributes" do

--- a/test/parser/void_elements_aliases_test.exs
+++ b/test/parser/void_elements_aliases_test.exs
@@ -1,7 +1,7 @@
-defmodule Temple.Parser.VoidElementsAliasesTest do
+defmodule Temple.Ast.VoidElementsAliasesTest do
   use ExUnit.Case, async: true
 
-  alias Temple.Parser.VoidElementsAliases
+  alias Temple.Ast.VoidElementsAliases
 
   describe "applicable?/1" do
     test "returns true when the node is a nonvoid element or alias" do

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -368,7 +368,7 @@ defmodule Temple.RendererTest do
       temple do
         div do
           "I am above the slot"
-          slot :inner_block
+          slot @inner_block
         end
       end
     end
@@ -406,11 +406,13 @@ defmodule Temple.RendererTest do
       temple do
         div do
           "#{@name} is above the slot"
-          slot :inner_block
+          slot @inner_block
         end
 
         footer do
-          slot :footer, %{name: @name}
+          for f <- @footer do
+            slot f, %{name: @name}
+          end
         end
       end
     end
@@ -543,11 +545,9 @@ defmodule Temple.RendererTest do
         <p>
           motchy boi's in the footer!
         </p>
-
         <p>
           motchy boi is the second footer!
         </p>
-
 
       </footer>
 

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -374,6 +374,8 @@ defmodule Temple.RendererTest do
     end
 
     test "component with default slot" do
+      assigns = %{}
+
       result =
         Renderer.compile do
           div do
@@ -414,6 +416,8 @@ defmodule Temple.RendererTest do
     end
 
     test "component with a named slot" do
+      assigns = %{}
+
       result =
         Renderer.compile do
           div do
@@ -497,6 +501,59 @@ defmodule Temple.RendererTest do
       # html
       expected = """
       <input type="text" placeholder="Enter some text...">
+      """
+
+      assert expected == result
+    end
+
+    test "multiple slots" do
+      assigns = %{}
+
+      result =
+        Renderer.compile do
+          div do
+            c &named_slot/1, name: "motchy boi" do
+              span do: "i'm a slot"
+
+              slot :footer, %{name: name} do
+                p do
+                  "#{name}'s in the footer!"
+                end
+              end
+
+              slot :footer, %{name: name} do
+                p do
+                  "#{name} is the second footer!"
+                end
+              end
+            end
+          end
+        end
+
+      # heex
+      expected = """
+      <div>
+      <div>
+        motchy boi is above the slot
+        <span>i'm a slot</span>
+
+      </div>
+
+      <footer>
+        <p>
+          motchy boi's in the footer!
+        </p>
+
+        <p>
+          motchy boi is the second footer!
+        </p>
+
+
+      </footer>
+
+
+      </div>
+
       """
 
       assert expected == result

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -368,7 +368,7 @@ defmodule Temple.RendererTest do
       temple do
         div do
           "I am above the slot"
-          slot :default
+          slot :inner_block
         end
       end
     end
@@ -406,7 +406,7 @@ defmodule Temple.RendererTest do
       temple do
         div do
           "#{@name} is above the slot"
-          slot :default
+          slot :inner_block
         end
 
         footer do

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -411,6 +411,7 @@ defmodule Temple.RendererTest do
 
         footer do
           for f <- @footer do
+            span do: f[:label]
             slot f, %{name: @name}
           end
         end
@@ -418,7 +419,7 @@ defmodule Temple.RendererTest do
     end
 
     test "component with a named slot" do
-      assigns = %{}
+      assigns = %{label: "i'm a slot attribute"}
 
       result =
         Renderer.compile do
@@ -426,7 +427,7 @@ defmodule Temple.RendererTest do
             c &named_slot/1, name: "motchy boi" do
               span do: "i'm a slot"
 
-              slot :footer, %{name: name} do
+              slot :footer, let: %{name: name}, label: @label, expr: 1 + 1 do
                 p do
                   "#{name}'s in the footer!"
                 end
@@ -445,6 +446,7 @@ defmodule Temple.RendererTest do
       </div>
 
       <footer>
+        <span>i'm a slot attribute</span>
         <p>
           motchy boi's in the footer!
         </p>
@@ -517,13 +519,13 @@ defmodule Temple.RendererTest do
             c &named_slot/1, name: "motchy boi" do
               span do: "i'm a slot"
 
-              slot :footer, %{name: name} do
+              slot :footer, let: %{name: name} do
                 p do
                   "#{name}'s in the footer!"
                 end
               end
 
-              slot :footer, %{name: name} do
+              slot :footer, let: %{name: name} do
                 p do
                   "#{name} is the second footer!"
                 end
@@ -542,9 +544,11 @@ defmodule Temple.RendererTest do
       </div>
 
       <footer>
+        <span></span>
         <p>
           motchy boi's in the footer!
         </p>
+        <span></span>
         <p>
           motchy boi is the second footer!
         </p>


### PR DESCRIPTION
This change aligns the component model with HEEx/Surface. This shoudl
allow one to interop components created in any syntax with any other
syntax.

The advantage of this is folks can utilize component packages created
using a different syntax.

This should also close https://github.com/mhanberg/temple/issues/130.

## TODO

- [x] Test interop of components between HEEx and Temple.
- [x] Test passing single args to slots that are not maps.
- [x] Slot attributes
- [x] Improve code quality. Currently was a hacky pass to get it to work at all.
- [x] Docs
- [x] Changelog
- [x] Migration Guide

## Notes

Example project showing how component from both template packages can be used with each other seamlessly https://github.com/mhanberg/temple_heex_interop/blob/main/lib/temple_heex_interop_web/views/page_view.ex.

<img width="955" alt="image" src="https://user-images.githubusercontent.com/5523984/192696574-fc390add-66e6-4ba9-9195-45a4842ea5c1.png">
