### PR TITLE
feat: Add missing HTML tags

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "27.1.1"
+elixir = "1.17.3-otp-27"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.14.0-otp-25
-erlang 25.0-rc2

--- a/lib/temple/parser.ex
+++ b/lib/temple/parser.ex
@@ -139,6 +139,7 @@ defmodule Temple.Parser do
     head title style script
     noscript template
     body section nav article aside h1 h2 h3 h4 h5 h6
+    hgroup search picture dialog
     header footer address main
     p pre blockquote ol ul li dl dt dd figure figcaption div
     a em strong small s cite q dfn abbr data time code var samp kbd
@@ -160,9 +161,30 @@ defmodule Temple.Parser do
                              {Keyword.get(@aliases, el, el), el}
                            end)
 
-  def nonvoid_elements, do: @nonvoid_elements ++ Keyword.values(@nonvoid_svg_aliases)
-  def nonvoid_elements_aliases, do: @nonvoid_elements_aliases ++ @nonvoid_svg_aliases
-  def nonvoid_elements_lookup, do: @nonvoid_elements_lookup ++ @nonvoid_svg_lookup
+  @nonvoid_mathml_elements ~w[
+    math
+    mi mn mo ms mspace mtext
+    merror mfrac mpadded mphantom mroot mrow msqrt mstyle
+    mmultiscripts mover msub msubsup msup munder munderover
+    mtable mtd mtr
+    annotation semantics
+  ]a
+
+  @nonvoid_mathml_lookup Keyword.new(@nonvoid_mathml_elements, &{&1, &1}) ++
+                           [annotation_xml: "annotation-xml"]
+
+  @nonvoid_mathml_aliases Keyword.keys(@nonvoid_mathml_lookup)
+
+  def nonvoid_elements,
+    do:
+      @nonvoid_elements ++
+        Keyword.values(@nonvoid_svg_lookup) ++ Keyword.values(@nonvoid_mathml_lookup)
+
+  def nonvoid_elements_aliases,
+    do: @nonvoid_elements_aliases ++ @nonvoid_svg_aliases ++ @nonvoid_mathml_aliases
+
+  def nonvoid_elements_lookup,
+    do: @nonvoid_elements_lookup ++ @nonvoid_svg_lookup ++ @nonvoid_mathml_lookup
 
   @void_elements ~w[
     meta link base
@@ -174,9 +196,19 @@ defmodule Temple.Parser do
                           {Keyword.get(@aliases, el, el), el}
                         end)
 
-  def void_elements, do: @void_elements ++ Keyword.values(@void_svg_aliases)
-  def void_elements_aliases, do: @void_elements_aliases ++ @void_svg_aliases
-  def void_elements_lookup, do: @void_elements_lookup ++ @void_svg_lookup
+  @void_mathml_lookup [
+    mprescripts: "mprescripts"
+  ]
+
+  @void_mathml_aliases Keyword.keys(@void_mathml_lookup)
+
+  def void_elements,
+    do: @void_elements ++ Keyword.values(@void_svg_lookup) ++ Keyword.values(@void_mathml_lookup)
+
+  def void_elements_aliases,
+    do: @void_elements_aliases ++ @void_svg_aliases ++ @void_mathml_aliases
+
+  def void_elements_lookup, do: @void_elements_lookup ++ @void_svg_lookup ++ @void_mathml_lookup
 
   def parsers() do
     [


### PR DESCRIPTION
- **chore: Switch from .tool-versions to .mise.toml**

  This also modernized the configured versions.

- **feat: add missing and new HTML elements & MathML**

  This update is based on the list of tags in MDN.

  - Added widely available tags `hgroup`, `picture`, and `dialog`.
  - Added the new tag `search`, which is part of baseline 2023.
  - Did NOT add `portal` and `fencedframe`; these are experimental and currently available to Chromium-based browsers.
  - Added MathML tags. These have been kept separate following the example of SVG.
  - Fixed a bug in `Temple.Parser.nonvoide_elements/0` and `Temple.Parser.void_elements/0` which was trying to call `Keyword.keys` on a straight list of values.
