### PR TITLE
fix!: pass rest! assign as @rest to components

### DIFF
--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -117,15 +117,10 @@ defmodule Temple.Renderer do
 
     component_arguments =
       {:%{}, [],
-       arguments
+       (arguments ++ [rest: rest])
        |> Map.new()
        |> Map.merge(slot_quotes)
        |> Enum.to_list()}
-
-    component_arguments =
-      quote do
-        Map.merge(unquote(component_arguments), Map.new(unquote(rest)))
-      end
 
     expr =
       quote do
@@ -135,6 +130,7 @@ defmodule Temple.Renderer do
           {__MODULE__, __ENV__.function, __ENV__.file, __ENV__.line}
         )
       end
+      |> tag_slots(Enum.map(slots, & &1.name))
 
     state.engine.handle_expr(buffer, "=", expr)
   end
@@ -375,4 +371,10 @@ defmodule Temple.Renderer do
 
   def new_line(%{terminal_node: false}), do: "\n"
   def new_line(%{terminal_node: true}), do: ""
+
+  # the liveview engine expects the ast meta
+  # to have this metadata
+  defp tag_slots({call, meta, args}, slots) do
+    {call, [slots: slots] ++ meta, args}
+  end
 end

--- a/test/support/components.ex
+++ b/test/support/components.ex
@@ -44,8 +44,8 @@ defmodule Temple.Support.Components do
 
   def rest_component(assigns) do
     temple do
-      div do
-        "I am a basic #{@id} with #{@class}"
+      div id: @id, rest!: @rest do
+        inspect(@rest)
       end
     end
   end

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -636,7 +636,7 @@ defmodule Temple.RendererTest do
       assert_html expected, result
     end
 
-    test "rest! attribute can mix in dynamic assigns to components" do
+    test "rest! attribute can is passed as @rest to component assigns" do
       assigns = %{
         rest: [
           class: "font-bold"
@@ -650,8 +650,8 @@ defmodule Temple.RendererTest do
 
       # heex
       expected = """
-      <div>
-        I am a basic foo with font-bold
+      <div id="foo" class="font-bold">
+        [class: &quot;font-bold&quot;]
       </div>
 
       """


### PR DESCRIPTION
Previously, when you passed data as a `rest!` assign to a component, it
compiled it into a call that ran it throught a Map.merge with the rest
of the assigns at runtime.

This allowed you to access to data passed as `@foo` if you passed it as
`rest!: [foo: "bar"]`.

This implementation conflicted with the `Phoenix.LiveView.Engine` and
made it so LiveComponents didn't work.

This implementation also just differed from HEEx, which is probably
confusing.

Fixes #254

Thank you @SteffenDE for the help!
