### PR TITLE
fix!: correctly use rest in components

### DIFF
--- a/lib/temple/renderer.ex
+++ b/lib/temple/renderer.ex
@@ -113,10 +113,15 @@ defmodule Temple.Renderer do
 
     component_arguments =
       {:%{}, [],
-       (arguments ++ [rest: quote(do: Map.new(unquote(rest)))])
+       arguments
        |> Map.new()
        |> Map.merge(slot_quotes)
        |> Enum.to_list()}
+
+    component_arguments =
+      quote do
+        Map.merge(Map.new(unquote(rest)), unquote(component_arguments))
+      end
 
     expr =
       quote do

--- a/test/temple/renderer_test.exs
+++ b/test/temple/renderer_test.exs
@@ -636,29 +636,6 @@ defmodule Temple.RendererTest do
       assert_html expected, result
     end
 
-    test "rest! attribute can is passed as @rest to component assigns" do
-      assigns = %{
-        rest: [
-          class: "font-bold"
-        ]
-      }
-
-      result =
-        Renderer.compile do
-          c &rest_component/1, id: "foo", rest!: @rest
-        end
-
-      # heex
-      expected = """
-      <div id="foo" class="font-bold">
-        %{class: &quot;font-bold&quot;}
-      </div>
-
-      """
-
-      assert_html expected, result
-    end
-
     test "rest! attribute can mix in dynamic attributes to slots" do
       assigns = %{
         rest: [


### PR DESCRIPTION
The `:rest!` assign in components no longer creates an `@rest` assign.
You can get the dynamic assigns as you normally would with the at
syntax, but if you want a 'rest' style assign, you can use the phoenix
component declarative macros, are by doing it yourself.
