### PR TITLE
docs: fix references to the default EEx engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ end
 
 ### Engine
 
-By default, Temple will use the `Phoenix.HTML.Engine`.
-It provides HTML escaping and returns it in `{:safe, html}`.
+By default, Temple will use [Phoenix.HTML.Engine](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Engine.html) from [phoenix_html](https://github.com/phoenixframework/phoenix_html), which provides HTML escaping.
 You can use any other engine that implements the `EEx.Engine` behaviour,
 such as `EEx.SmartEngine` or [Aino.View.Engine](https://github.com/oestrich/aino).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![Temple](temple-github-image.png)
 
-
 [![Actions Status](https://github.com/mhanberg/temple/workflows/CI/badge.svg)](https://github.com/mhanberg/temple/actions)
 [![Hex.pm](https://img.shields.io/hexpm/v/temple.svg)](https://hex.pm/packages/temple)
 
@@ -126,13 +125,16 @@ end
 
 ### Engine
 
-By default, Temple will use the `EEx.SmartEngine` that is built into the Elixir standard library. If you are a web framework that uses it's own template engine (such as [Aino](https://github.com/oestrich/aino) and Phoenix/LiveView, you can configure Temple to it!
+By default, Temple will use the `Phoenix.HTML.Engine`.
+It provides HTML escaping and returns it in `{:safe, html}`.
+You can use any other engine that implements the `EEx.Engine` behaviour,
+such as `EEx.SmartEngine` or [Aino.View.Engine](https://github.com/oestrich/aino).
 
 ```elixir
 # config/config.exs
 
 config :temple,
-  engine: Aino.View.Engine # or Phoenix.HTML.Engine or Phoenix.LiveView.Engine
+  engine: Aino.View.Engine # or EEx.SmartEngine or Phoenix.LiveView.Engine
 ```
 
 ### Formatter

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -15,25 +15,6 @@ Add `:temple` to your deps and run `mix deps.get`
 {:temple, "~> 0.14.0"}
 ```
 
-Now you must prepend the Temple compiler to your projects `:compilers` configuration in `mix.exs`. There is a chance that your project doesn't set this option at all, but don't worry, it's really easy to add!
-
-```elixir
-defmodule MyApp.MixProject do
-  use Mix.Project
-
-  def project do
-    [
-      # ...
-      compilers: [:temple] ++ Mix.compilers(),
-      # ...
-    ]
-  end
-
-# ...
-
-end
-```
-
 All done, Now let's start building our app!
 
 ## Configuration

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -6,7 +6,6 @@ Welcome!
 
 Temple is an HTML DSL for Elixir; let's get started!
 
-
 First, make sure you are using Elixir `V1.13` or higher.
 
 Add `:temple` to your deps and run `mix deps.get`
@@ -14,6 +13,20 @@ Add `:temple` to your deps and run `mix deps.get`
 ```elixir
 {:temple, "~> 0.14.0"}
 ```
+
+Add `:temple` to `:compilers` option in `project/0` callback in your Mix project module
+to handle [whitespace](https://hexdocs.pm/temple/your-first-template.html#whitespace) correctly.
+
+```elixir
+# mix.exs
+
+def project do
+  [
+    # ...
+    compilers: [:temple] ++ Mix.compilers()
+  ]
+end
+ ```
 
 All done, Now let's start building our app!
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -6,6 +6,7 @@ Welcome!
 
 Temple is an HTML DSL for Elixir; let's get started!
 
+
 First, make sure you are using Elixir `V1.13` or higher.
 
 Add `:temple` to your deps and run `mix deps.get`
@@ -14,19 +15,24 @@ Add `:temple` to your deps and run `mix deps.get`
 {:temple, "~> 0.14.0"}
 ```
 
-Add `:temple` to `:compilers` option in `project/0` callback in your Mix project module
-to handle [whitespace](https://hexdocs.pm/temple/your-first-template.html#whitespace) correctly.
+To handle [whitespace](your-first-template.html#whitespace) correctly, prepend the Temple compiler to your projects `:compilers` configuration in `mix.exs`. There is a chance that your project doesn't set this option at all, but don't worry, it's really easy to add!
 
 ```elixir
-# mix.exs
+defmodule MyApp.MixProject do
+  use Mix.Project
 
-def project do
-  [
-    # ...
-    compilers: [:temple] ++ Mix.compilers()
-  ]
+  def project do
+    [
+      # ...
+      compilers: [:temple] ++ Mix.compilers(),
+      # ...
+    ]
+  end
+
+# ...
+
 end
- ```
+```
 
 All done, Now let's start building our app!
 

--- a/guides/your-first-template.md
+++ b/guides/your-first-template.md
@@ -183,7 +183,7 @@ end
 
 ## Assigns
 
-The default engines `Phoenix.HTML.Engine` supports the `@` syntax for `assigns` parameter.
+The default engine `Phoenix.HTML.Engine` supports the `@` syntax for `assigns` parameter.
 The syntax allows you to ergonomically access `assigns.member` by `@member`.
 
 The assign variable just needs to exist within the scope of the template.

--- a/guides/your-first-template.md
+++ b/guides/your-first-template.md
@@ -68,7 +68,7 @@ The text node is a basic building block of any HTML document. In Temple, text no
 
 The very first line of the previous example is our doc type, emitted into the final document with `"<!DOCTYPE html>"`. This is a text node that will be emitted into the document as-is.
 
-Note: String _literals_ are emitted into text nodes. If you are using string interpolation with the `#{some_expression}` syntax, that is treated as an expression and will be evaluated in whichever way the configured engine evaluates expression. By default, the `EEx.SmartEngine` doesn't do any escaping of expressions, so that could still be emitted as-is, or even as HTML to be interpreted by your web browser.
+Note: String _literals_ are emitted into text nodes. If you are using string interpolation with the `#{some_expression}` syntax, that is treated as an expression and will be evaluated in whichever way the configured engine evaluates expression.
 
 ## Void Tags
 
@@ -183,11 +183,11 @@ end
 
 ## Assigns
 
-Since Temple uses the `EEx.SmartEngine` by default, you can use the assigns feature.
+The default engines `Phoenix.HTML.Engine` supports the `@` syntax for `assigns` parameter.
+The syntax allows you to ergonomically access `assigns.member` by `@member`.
 
-The assigns feature allows you to ergonomically access the members of a `assigns` variable by the `@` macro.
-
-The assign variable just needs to exist within the scope of the template (the same as a normal `EEx` template that uses `EEx.SmartEngine`), it can be a function parameter or created inside the function.
+The assign variable just needs to exist within the scope of the template.
+It can be a function parameter or created inside the function.
 
 ```elixir
 def card(assigns) do

--- a/guides/your-first-template.md
+++ b/guides/your-first-template.md
@@ -68,7 +68,7 @@ The text node is a basic building block of any HTML document. In Temple, text no
 
 The very first line of the previous example is our doc type, emitted into the final document with `"<!DOCTYPE html>"`. This is a text node that will be emitted into the document as-is.
 
-Note: String _literals_ are emitted into text nodes. If you are using string interpolation with the `#{some_expression}` syntax, that is treated as an expression and will be evaluated in whichever way the configured engine evaluates expression.
+Note: String _literals_ are emitted into text nodes. If you are using string interpolation with the `#{some_expression}` syntax, that is treated as an expression and will be evaluated in whichever way the configured engine evaluates expression. Some engines like `EEx.SmartEngine` doesn't do any escaping of expressions, so that could still be emitted as-is, or even as HTML to be interpreted by your web browser.
 
 ## Void Tags
 
@@ -183,11 +183,11 @@ end
 
 ## Assigns
 
-The default engine `Phoenix.HTML.Engine` supports the `@` syntax for `assigns` parameter.
-The syntax allows you to ergonomically access `assigns.member` by `@member`.
+Since Temple uses the `Phoenix.HTML.Engine` by default, you can use the assigns feature.
 
-The assign variable just needs to exist within the scope of the template.
-It can be a function parameter or created inside the function.
+The assigns feature allows you to ergonomically access the members of a `assigns` variable by the `@` macro.
+
+The assign variable just needs to exist within the scope of the template (the same as a normal `EEx` template that uses `EEx.SmartEngine`), it can be a function parameter or created inside the function.
 
 ```elixir
 def card(assigns) do

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -56,15 +56,18 @@ defmodule Temple do
 
   ### Engine
 
-  By default Temple wil use the `EEx.SmartEngine`, but you can configure it to use any other engine. Examples could be `Phoenix.HTML.Engine` or `Phoenix.LiveView.Engine`.
+  By default Temple wil use the `Phoenix.HTML.Engine`,
+  but you can configure it to use any other engine that implements the `EEx.SmartEngine`.
+  Examples could be `EEx.SmartEngine` or `Phoenix.LiveView.Engine`.
 
   ```elixir
-  config :temple, engine: Phoenix.HTML.Engine
+  config :temple, engine: EEx.SmartEngine
   ```
 
   ### Aliases
 
-  You can add an alias for an element if there is a namespace collision with a function. If you are using `Phoenix.HTML`, there will be namespace collisions with the `<link>` and `<label>` elements.
+  You can add an alias for an element if there is a namespace collision with a function.
+  If you are using `Phoenix.HTML`, there will be namespace collisions with the `<link>` and `<label>` elements.
 
   ```elixir
   config :temple, :aliases,

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -56,18 +56,15 @@ defmodule Temple do
 
   ### Engine
 
-  By default Temple wil use the `Phoenix.HTML.Engine`,
-  but you can configure it to use any other engine that implements the `EEx.SmartEngine`.
-  Examples could be `EEx.SmartEngine` or `Phoenix.LiveView.Engine`.
+  By default Temple wil use the `EEx.SmartEngine`, but you can configure it to use any other engine. Examples could be `Phoenix.HTML.Engine` or `Phoenix.LiveView.Engine`.
 
   ```elixir
-  config :temple, engine: EEx.SmartEngine
+  config :temple, engine: Phoenix.HTML.Engine
   ```
 
   ### Aliases
 
-  You can add an alias for an element if there is a namespace collision with a function.
-  If you are using `Phoenix.HTML`, there will be namespace collisions with the `<link>` and `<label>` elements.
+  You can add an alias for an element if there is a namespace collision with a function. If you are using `Phoenix.HTML`, there will be namespace collisions with the `<link>` and `<label>` elements.
 
   ```elixir
   config :temple, :aliases,

--- a/lib/temple.ex
+++ b/lib/temple.ex
@@ -56,10 +56,10 @@ defmodule Temple do
 
   ### Engine
 
-  By default Temple wil use the `EEx.SmartEngine`, but you can configure it to use any other engine. Examples could be `Phoenix.HTML.Engine` or `Phoenix.LiveView.Engine`.
+  By default Temple wil use the `Phoenix.HTML.Engine`, but you can configure it to use any other engine. Examples could be `EEx.SmartEngine` or `Phoenix.LiveView.Engine`.
 
   ```elixir
-  config :temple, engine: Phoenix.HTML.Engine
+  config :temple, engine: EEx.SmartEngine
   ```
 
   ### Aliases


### PR DESCRIPTION
Promised in https://github.com/mhanberg/temple/discussions/273

Also, I think it’d be beneficial to clarify

```ex
{:safe, body} = View.render(conn.assigns)
```

as an idiom for Plug users using the default engine.