### PR TITLE
feat(parser): apply element aliases to SVG and MathML elements

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,8 @@ import Config
 config :temple,
   aliases: [
     select: :select__,
-    link: :link__
+    link: :link__,
+    text: :text__,
+    path: :path__,
+    mtext: :mtext__
   ]

--- a/lib/temple/parser.ex
+++ b/lib/temple/parser.ex
@@ -41,7 +41,13 @@ defmodule Temple.Parser do
     use: "use"
   ]
 
-  @void_svg_aliases Keyword.keys(@void_svg_lookup)
+  @void_svg_aliases Enum.map(@void_svg_lookup, fn {el, _} ->
+                      Keyword.get(@aliases, el, el)
+                    end)
+
+  @void_svg_aliased_lookup Enum.map(@void_svg_lookup, fn {el, html} ->
+                             {Keyword.get(@aliases, el, el), html}
+                           end)
 
   @nonvoid_svg_lookup [
     a: "a",
@@ -131,7 +137,13 @@ defmodule Temple.Parser do
     vkern: "vkern"
   ]
 
-  @nonvoid_svg_aliases Keyword.keys(@nonvoid_svg_lookup)
+  @nonvoid_svg_aliases Enum.map(@nonvoid_svg_lookup, fn {el, _} ->
+                         Keyword.get(@aliases, el, el)
+                       end)
+
+  @nonvoid_svg_aliased_lookup Enum.map(@nonvoid_svg_lookup, fn {el, html} ->
+                                {Keyword.get(@aliases, el, el), html}
+                              end)
 
   # nonvoid tags
 
@@ -173,7 +185,13 @@ defmodule Temple.Parser do
   @nonvoid_mathml_lookup Keyword.new(@nonvoid_mathml_elements, &{&1, &1}) ++
                            [annotation_xml: "annotation-xml"]
 
-  @nonvoid_mathml_aliases Keyword.keys(@nonvoid_mathml_lookup)
+  @nonvoid_mathml_aliases Enum.map(@nonvoid_mathml_lookup, fn {el, _} ->
+                            Keyword.get(@aliases, el, el)
+                          end)
+
+  @nonvoid_mathml_aliased_lookup Enum.map(@nonvoid_mathml_lookup, fn {el, html} ->
+                                   {Keyword.get(@aliases, el, el), html}
+                                 end)
 
   def nonvoid_elements,
     do:
@@ -184,7 +202,9 @@ defmodule Temple.Parser do
     do: @nonvoid_elements_aliases ++ @nonvoid_svg_aliases ++ @nonvoid_mathml_aliases
 
   def nonvoid_elements_lookup,
-    do: @nonvoid_elements_lookup ++ @nonvoid_svg_lookup ++ @nonvoid_mathml_lookup
+    do:
+      @nonvoid_elements_lookup ++
+        @nonvoid_svg_aliased_lookup ++ @nonvoid_mathml_aliased_lookup
 
   @void_elements ~w[
     meta link base
@@ -200,7 +220,13 @@ defmodule Temple.Parser do
     mprescripts: "mprescripts"
   ]
 
-  @void_mathml_aliases Keyword.keys(@void_mathml_lookup)
+  @void_mathml_aliases Enum.map(@void_mathml_lookup, fn {el, _} ->
+                         Keyword.get(@aliases, el, el)
+                       end)
+
+  @void_mathml_aliased_lookup Enum.map(@void_mathml_lookup, fn {el, html} ->
+                                {Keyword.get(@aliases, el, el), html}
+                              end)
 
   def void_elements,
     do: @void_elements ++ Keyword.values(@void_svg_lookup) ++ Keyword.values(@void_mathml_lookup)
@@ -211,7 +237,10 @@ defmodule Temple.Parser do
   def void_elements_aliases,
     do: @void_elements_aliases ++ @void_svg_aliases ++ @void_mathml_aliases
 
-  def void_elements_lookup, do: @void_elements_lookup ++ @void_svg_lookup ++ @void_mathml_lookup
+  def void_elements_lookup,
+    do:
+      @void_elements_lookup ++
+        @void_svg_aliased_lookup ++ @void_mathml_aliased_lookup
 
   def parsers() do
     [

--- a/test/temple/ast/nonvoid_elements_aliases_test.exs
+++ b/test/temple/ast/nonvoid_elements_aliases_test.exs
@@ -119,5 +119,38 @@ defmodule Temple.Ast.NonvoidElementsAliasesTest do
                }
              } = ast
     end
+
+    test "uses the configured alias for an SVG element" do
+      raw_ast =
+        quote do
+          text__ x: "10" do
+            "label"
+          end
+        end
+
+      ast = NonvoidElementsAliases.run(raw_ast)
+
+      assert %NonvoidElementsAliases{
+               name: "text",
+               attrs: [x: "10"],
+               children: %ElementList{children: [%Text{text: "label"}]}
+             } = ast
+    end
+
+    test "uses the configured alias for a MathML element" do
+      raw_ast =
+        quote do
+          mtext__ do
+            "label"
+          end
+        end
+
+      ast = NonvoidElementsAliases.run(raw_ast)
+
+      assert %NonvoidElementsAliases{
+               name: "mtext",
+               children: %ElementList{children: [%Text{text: "label"}]}
+             } = ast
+    end
   end
 end

--- a/test/temple/ast/nonvoid_elements_aliases_test.exs
+++ b/test/temple/ast/nonvoid_elements_aliases_test.exs
@@ -45,6 +45,39 @@ defmodule Temple.Ast.NonvoidElementsAliasesTest do
         refute NonvoidElementsAliases.applicable?(raw_ast)
       end
     end
+
+    test "returns true for an SVG element alias" do
+      raw_ast =
+        quote do
+          text__ do
+            "label"
+          end
+        end
+
+      assert NonvoidElementsAliases.applicable?(raw_ast)
+    end
+
+    test "returns false for the original SVG name when it has been aliased" do
+      raw_ast =
+        quote do
+          text do
+            "label"
+          end
+        end
+
+      refute NonvoidElementsAliases.applicable?(raw_ast)
+    end
+
+    test "returns true for a MathML element alias" do
+      raw_ast =
+        quote do
+          mtext__ do
+            "label"
+          end
+        end
+
+      assert NonvoidElementsAliases.applicable?(raw_ast)
+    end
   end
 
   describe "run/2" do

--- a/test/temple/ast/void_elements_aliases_test.exs
+++ b/test/temple/ast/void_elements_aliases_test.exs
@@ -37,6 +37,33 @@ defmodule Temple.Ast.VoidElementsAliasesTest do
         refute VoidElementsAliases.applicable?(raw_ast)
       end
     end
+
+    test "returns true for an SVG void element alias" do
+      raw_ast =
+        quote do
+          path__(d: "M0 0")
+        end
+
+      assert VoidElementsAliases.applicable?(raw_ast)
+    end
+
+    test "returns false for the original SVG void name when it has been aliased" do
+      raw_ast =
+        quote do
+          path d: "M0 0"
+        end
+
+      refute VoidElementsAliases.applicable?(raw_ast)
+    end
+
+    test "returns true for an unaliased MathML void element name" do
+      raw_ast =
+        quote do
+          mprescripts(foo: "bar")
+        end
+
+      assert VoidElementsAliases.applicable?(raw_ast)
+    end
   end
 
   describe "run/2" do

--- a/test/temple/ast/void_elements_aliases_test.exs
+++ b/test/temple/ast/void_elements_aliases_test.exs
@@ -80,5 +80,33 @@ defmodule Temple.Ast.VoidElementsAliasesTest do
                attrs: [content: "foo"]
              } = ast
     end
+
+    test "uses the configured alias for an SVG void element" do
+      raw_ast =
+        quote do
+          path__(d: "M0 0")
+        end
+
+      ast = VoidElementsAliases.run(raw_ast)
+
+      assert %VoidElementsAliases{
+               name: "path",
+               attrs: [d: "M0 0"]
+             } = ast
+    end
+
+    test "passes through an unaliased MathML void element" do
+      raw_ast =
+        quote do
+          mprescripts(foo: "bar")
+        end
+
+      ast = VoidElementsAliases.run(raw_ast)
+
+      assert %VoidElementsAliases{
+               name: "mprescripts",
+               attrs: [foo: "bar"]
+             } = ast
+    end
   end
 end

--- a/test/temple_test.exs
+++ b/test/temple_test.exs
@@ -29,6 +29,54 @@ defmodule TempleTest do
 
       assert expected == result
     end
+
+    test "compiles an SVG element alias" do
+      assigns = %{}
+      _ = assigns
+
+      result =
+        temple do
+          text__ x: "10", y: "20" do
+            "label"
+          end
+        end
+        |> Phoenix.HTML.safe_to_string()
+
+      assert result =~ ~s|<text x="10" y="20">|
+      assert result =~ "label"
+      assert result =~ "</text>"
+    end
+
+    test "compiles an SVG void element alias" do
+      assigns = %{}
+      _ = assigns
+
+      result =
+        temple do
+          path__ d: "M0 0"
+        end
+        |> Phoenix.HTML.safe_to_string()
+
+      assert result =~ ~s|<path d="M0 0"|
+      refute result =~ "</path>"
+    end
+
+    test "compiles a MathML element alias" do
+      assigns = %{}
+      _ = assigns
+
+      result =
+        temple do
+          mtext__ do
+            "label"
+          end
+        end
+        |> Phoenix.HTML.safe_to_string()
+
+      assert result =~ "<mtext>"
+      assert result =~ "label"
+      assert result =~ "</mtext>"
+    end
   end
 
   describe "attributes/1" do


### PR DESCRIPTION
Tag names for SVG and MathML elements were not being run through the configured `:aliases` map, so users could not alias them to clear out collisions with surrounding variable or function names. The HTML element list applied `@aliases` when building its `*_aliases` and `*_lookup` attributes, but the SVG and MathML lists used `Keyword.keys/1` on the raw lookups, ignoring the user's configuration.

This applies the same `Keyword.get(@aliases, el, el)` rewrite to the SVG and MathML void and nonvoid lookups, mirroring the existing HTML path. Public APIs and defaults are unchanged when no aliases are configured.

Tests cover an aliased SVG nonvoid element, an aliased SVG void element, an aliased MathML nonvoid element, an unaliased MathML void element (regression guard), and that the original SVG name no longer matches after it has been aliased.

Closes #279
